### PR TITLE
Add 'git' to installExtras and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+doc/

--- a/extra.js
+++ b/extra.js
@@ -2,7 +2,7 @@ import { exec as _exec } from '@actions/exec';
 import { startGroup, endGroup, info } from '@actions/core';
 
 export async function installExtras(env = 'fortran', extras = []) {
-  const pkgs = ['fpm', ...extras.map(p => p.trim()).filter(Boolean)];
+  const pkgs = ['git', 'fpm', ...extras.map(p => p.trim()).filter(Boolean)];
   if (!pkgs.length) return;
 
   startGroup(`Installing extra packages: ${pkgs.join(', ')}`);


### PR DESCRIPTION
Include 'git' in the list of extra packages for installation and add 'doc/' to .gitignore to prevent documentation files from being tracked in version control.