### PR TITLE
fix: ensure consistent compiler versions for Fortran and C/C++

### DIFF
--- a/platform/lin/flang-new.js
+++ b/platform/lin/flang-new.js
@@ -48,8 +48,14 @@ export async function setup(version = '') {
   }
 
   // Define the set of Conda packages to install
-  const Pkg = version ? `flang=${version}` : 'flang';
-  const packages = [Pkg, 'llvm', 'clang-tools', 'llvm-openmp', 'lld'];
+  const packages = [
+    version ? `flang=${version}` : 'flang',
+    version ? `llvm=${version}` : 'llvm',
+    version ? `clangxx=${version}` : 'clangxx',
+    version ? `clang-tools=${version}` : 'clang-tools',
+    version ? `llvm-openmp=${version}` : 'llvm-openmp',
+    version ? `lld=${version}` : 'lld'
+  ];
 
   startGroup('Installing Conda packages');
   try {

--- a/platform/lin/flang.js
+++ b/platform/lin/flang.js
@@ -48,8 +48,14 @@ export async function setup(version = '') {
   }
 
   // Define the set of Conda packages to install
-  const Pkg = version ? `flang=${version}` : 'flang';
-  const packages = [Pkg, 'llvm', 'clangxx', 'clang-tools', 'llvm-openmp', 'lld'];
+  const packages = [
+    version ? `flang=${version}` : 'flang',
+    version ? `llvm=${version}` : 'llvm',
+    version ? `clangxx=${version}` : 'clangxx',
+    version ? `clang-tools=${version}` : 'clang-tools',
+    version ? `llvm-openmp=${version}` : 'llvm-openmp',
+    version ? `lld=${version}` : 'lld'
+  ];
 
   startGroup('Installing Conda packages');
   try {

--- a/platform/lin/gfortran.js
+++ b/platform/lin/gfortran.js
@@ -48,8 +48,12 @@ export async function setup(version = '') {
   }
 
   // Define the Conda packages to install
-  const Pkg = version ? `gfortran=${version}` : 'gfortran';
-  const packages = [Pkg, 'gcc_linux-64', 'gxx', 'binutils'];
+  const packages = [
+    version ? `gfortran=${version}` : 'gfortran',
+    version ? `gcc_linux-64=${version}` : 'gcc_linux-64',
+    version ? `gxx=${version}` : 'gxx',
+    'binutils'
+  ];
 
   startGroup('Installing Conda packages');
   try {

--- a/platform/lin/ifx.js
+++ b/platform/lin/ifx.js
@@ -48,8 +48,14 @@ export async function setup(version = '') {
   }
 
   // Define Conda packages
-  const Pkg = version ? `ifx_linux-64=${version}` : 'ifx_linux-64';
-  const packages = ['intel-fortran-rt', 'dpcpp-cpp-rt', 'dpcpp_linux-64', 'intel-sycl-rt', 'llvm-openmp', Pkg];
+  const packages = [
+    version ? `ifx_linux-64=${version}` : 'ifx_linux-64',
+    version ? `intel-fortran-rt=${version}` : 'intel-fortran-rt',
+    version ? `dpcpp-cpp-rt=${version}` : 'dpcpp-cpp-rt',
+    version ? `dpcpp_linux-64=${version}` : 'dpcpp_linux-64',
+    version ? `intel-sycl-rt=${version}` : 'intel-sycl-rt',
+    'llvm-openmp'
+  ];
 
   // Install required compilers and tools via Conda
   startGroup('Installing Conda packages');

--- a/platform/mac/gfortran.js
+++ b/platform/mac/gfortran.js
@@ -63,18 +63,30 @@ export async function setup(version = '') {
     throw new Error('This setup script is only supported on macOS.');
   }
 
-  // Install latest Homebrew GCC
-  startGroup('Installing gcc via Homebrew');
+  // Install Homebrew GCC
+  let gcc = '';
+  let gpp = '';
+  let major = '';
+
+  startGroup('Installing GCC via Homebrew');
   try {
-    await _exec('brew', ['install', 'gcc']);
-    info('Homebrew gcc installed');
+    if (version) {
+      major = version.split('.')[0];
+      await _exec('brew', ['install', `gcc@${major}`]);
+      info(`Homebrew gcc@${major} installed`);
+      gcc = `gcc-${major}`;
+      gpp = `g++-${major}`;
+    } else {
+      await _exec('brew', ['install', 'gcc']);
+      info('Homebrew latest gcc installed');
+      gcc = detectHomebrewGccVersion();       // e.g., "gcc-14"
+      gpp = gcc.replace('gcc', 'g++');        // e.g., "g++-14"
+      major = gcc.split('-')[1];              // extract "14" from "gcc-14"
+    }
   } catch (err) {
     throw new Error(`Homebrew gcc install failed: ${err.message}`);
   }
   endGroup();
-
-  const gcc = detectHomebrewGccVersion();       // e.g., gcc-13
-  const gpp = gcc.replace('gcc', 'g++');         // e.g., g++-13
 
   // Install gfortran via Conda
   const Pkg = version ? `gfortran=${version}` : 'gfortran';

--- a/platform/win/flang-new.js
+++ b/platform/win/flang-new.js
@@ -122,8 +122,15 @@ export async function setup(version = '') {
   }
 
   // Define the set of Conda packages to install
-  const Pkg = version ? `flang=${version}` : 'flang';
-  const packages = [Pkg, 'llvm', 'clang-tools', 'llvm-openmp', 'lld'];
+  const packages = [
+    version ? `flang=${version}` : 'flang',
+    version ? `llvm=${version}` : 'llvm',
+    version ? `clangxx=${version}` : 'clangxx',
+    version ? `clang-tools=${version}` : 'clang-tools',
+    version ? `llvm-openmp=${version}` : 'llvm-openmp',
+    version ? `lld=${version}` : 'lld'
+  ];
+
 
   // Prepare MSVC environment
   await runVcvars64();
@@ -173,6 +180,8 @@ export async function setup(version = '') {
   await _exec('flang', ['--version']);
   await _exec('where', ['clang-cl']);
   await _exec('clang-cl', ['--version']);
+  await _exec('where', ['clang++']);
+  await _exec('clang++', ['--version']);
   endGroup();
 
   // Export compiler-related environment variables
@@ -180,13 +189,13 @@ export async function setup(version = '') {
   const envVars = {
     FC: 'flang',
     CC: 'clang-cl',
-    CXX: 'clang-cl',
+    CXX: 'clang++',
     FPM_FC: 'flang',
     FPM_CC: 'clang-cl',
-    FPM_CXX: 'clang-cl',
+    FPM_CXX: 'clang++',
     CMAKE_Fortran_COMPILER: 'flang',
     CMAKE_C_COMPILER: 'clang-cl',
-    CMAKE_CXX_COMPILER: 'clang-cl',
+    CMAKE_CXX_COMPILER: 'clang++',
     INCLUDE: [join(prefix, 'Library', 'include'), process.env.INCLUDE || ''].filter(Boolean).join(';'),
   };
 

--- a/platform/win/flang.js
+++ b/platform/win/flang.js
@@ -122,8 +122,15 @@ export async function setup(version = '') {
   }
 
   // Define the set of Conda packages to install
-  const Pkg = version ? `flang=${version}` : 'flang';
-  const packages = [Pkg, 'llvm', 'clang-tools', 'llvm-openmp', 'lld'];
+  const packages = [
+    version ? `flang=${version}` : 'flang',
+    version ? `llvm=${version}` : 'llvm',
+    version ? `clangxx=${version}` : 'clangxx',
+    version ? `clang-tools=${version}` : 'clang-tools',
+    version ? `llvm-openmp=${version}` : 'llvm-openmp',
+    version ? `lld=${version}` : 'lld'
+  ];
+
 
   // Prepare MSVC environment
   await runVcvars64();
@@ -173,6 +180,8 @@ export async function setup(version = '') {
   await _exec('flang', ['--version']);
   await _exec('where', ['clang-cl']);
   await _exec('clang-cl', ['--version']);
+  await _exec('where', ['clang++']);
+  await _exec('clang++', ['--version']);
   endGroup();
 
   // Export compiler-related environment variables
@@ -180,13 +189,13 @@ export async function setup(version = '') {
   const envVars = {
     FC: 'flang',
     CC: 'clang-cl',
-    CXX: 'clang-cl',
+    CXX: 'clang++',
     FPM_FC: 'flang',
     FPM_CC: 'clang-cl',
-    FPM_CXX: 'clang-cl',
+    FPM_CXX: 'clang++',
     CMAKE_Fortran_COMPILER: 'flang',
     CMAKE_C_COMPILER: 'clang-cl',
-    CMAKE_CXX_COMPILER: 'clang-cl',
+    CMAKE_CXX_COMPILER: 'clang++',
     INCLUDE: [join(prefix, 'Library', 'include'), process.env.INCLUDE || ''].filter(Boolean).join(';'),
   };
 

--- a/platform/win/gfortran.js
+++ b/platform/win/gfortran.js
@@ -37,8 +37,13 @@ export async function setup(version = '') {
   }
 
   // Define the set of Conda packages to install
-  const Pkg = version ? `gfortran=${version}` : 'gfortran';
-  const packages = [Pkg, 'gcc', 'binutils'];
+  const packages = [
+    version ? `gfortran=${version}` : 'gfortran',
+    version ? `gcc=${version}` : 'gcc',
+    version ? `gxx=${version}` : 'gxx',
+    'binutils'
+  ];
+
 
   // Install required compilers and tools via Conda
   startGroup('Installing Conda packages');

--- a/platform/win/ifx.js
+++ b/platform/win/ifx.js
@@ -122,8 +122,14 @@ export async function setup(version = '') {
   }
 
   // Define the set of Conda packages to install
-  const Pkg = version ? `ifx_win-64=${version}` : 'ifx_win-64';
-  const packages = ['intel-fortran-rt', 'dpcpp-cpp-rt', 'dpcpp_win-64', 'intel-sycl-rt', 'llvm-openmp', Pkg];
+  const packages = [
+    version ? `ifx_win-64=${version}` : 'ifx_win-64',
+    version ? `intel-fortran-rt=${version}` : 'intel-fortran-rt',
+    version ? `dpcpp-cpp-rt=${version}` : 'dpcpp-cpp-rt',
+    version ? `dpcpp_win-64=${version}` : 'dpcpp_win-64',
+    version ? `intel-sycl-rt=${version}` : 'intel-sycl-rt',
+    'llvm-openmp'
+  ];
 
   // Prepare MSVC environment
   await runVcvars64();


### PR DESCRIPTION
- Ensure consistent compiler versions for `gcc`, `g++` and `gfortran`, as well as for all LLVM and Intel toolchains during the setup process.
 
- On macOS, the latest version of `gcc` available via Conda is `4.8.5`, which is outdated. As a workaround, `gcc` and `g++` are installed via Homebrew. See: #65

- Install `clangxx` alongside `flang`