### PR TITLE
fix: mixed Clang frontends on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The selected Fortran compiler is installed along with the corresponding C and C+
 | gfortran         | gcc        | g++          |
 | ifx              | icx        | icx          |
 | lfortran         | clang-cl   | clang-cl     |
-| flang, flang-new | clang-cl   | clang++      |
+| flang, flang-new | clang-cl   | clang-cl     |
 
 **The following environment variables are automatically set:**
 

--- a/platform/win/flang-new.js
+++ b/platform/win/flang-new.js
@@ -125,7 +125,6 @@ export async function setup(version = '') {
   const packages = [
     version ? `flang=${version}` : 'flang',
     version ? `llvm=${version}` : 'llvm',
-    version ? `clangxx=${version}` : 'clangxx',
     version ? `clang-tools=${version}` : 'clang-tools',
     version ? `llvm-openmp=${version}` : 'llvm-openmp',
     version ? `lld=${version}` : 'lld'
@@ -180,22 +179,19 @@ export async function setup(version = '') {
   await _exec('flang', ['--version']);
   await _exec('where', ['clang-cl']);
   await _exec('clang-cl', ['--version']);
-  await _exec('where', ['clang++']);
-  await _exec('clang++', ['--version']);
-  endGroup();
 
   // Export compiler-related environment variables
   startGroup('Exporting compiler environment variables');
   const envVars = {
     FC: 'flang',
     CC: 'clang-cl',
-    CXX: 'clang++',
+    CXX: 'clang-cl',
     FPM_FC: 'flang',
     FPM_CC: 'clang-cl',
-    FPM_CXX: 'clang++',
+    FPM_CXX: 'clang-cl',
     CMAKE_Fortran_COMPILER: 'flang',
     CMAKE_C_COMPILER: 'clang-cl',
-    CMAKE_CXX_COMPILER: 'clang++',
+    CMAKE_CXX_COMPILER: 'clang-cl',
     INCLUDE: [join(prefix, 'Library', 'include'), process.env.INCLUDE || ''].filter(Boolean).join(';'),
   };
 

--- a/platform/win/flang.js
+++ b/platform/win/flang.js
@@ -125,7 +125,6 @@ export async function setup(version = '') {
   const packages = [
     version ? `flang=${version}` : 'flang',
     version ? `llvm=${version}` : 'llvm',
-    version ? `clangxx=${version}` : 'clangxx',
     version ? `clang-tools=${version}` : 'clang-tools',
     version ? `llvm-openmp=${version}` : 'llvm-openmp',
     version ? `lld=${version}` : 'lld'
@@ -180,22 +179,19 @@ export async function setup(version = '') {
   await _exec('flang', ['--version']);
   await _exec('where', ['clang-cl']);
   await _exec('clang-cl', ['--version']);
-  await _exec('where', ['clang++']);
-  await _exec('clang++', ['--version']);
-  endGroup();
 
   // Export compiler-related environment variables
   startGroup('Exporting compiler environment variables');
   const envVars = {
     FC: 'flang',
     CC: 'clang-cl',
-    CXX: 'clang++',
+    CXX: 'clang-cl',
     FPM_FC: 'flang',
     FPM_CC: 'clang-cl',
-    FPM_CXX: 'clang++',
+    FPM_CXX: 'clang-cl',
     CMAKE_Fortran_COMPILER: 'flang',
     CMAKE_C_COMPILER: 'clang-cl',
-    CMAKE_CXX_COMPILER: 'clang++',
+    CMAKE_CXX_COMPILER: 'clang-cl',
     INCLUDE: [join(prefix, 'Library', 'include'), process.env.INCLUDE || ''].filter(Boolean).join(';'),
   };
 


### PR DESCRIPTION
Used clang-cl/clang-cl for C/C++ instead of clang-cl/clang++

fixes #67